### PR TITLE
Update regex to handle digits in jira id prefix

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -4,7 +4,7 @@ set -o pipefail
 echo "Extracting JIRA Issue number from: '${find_issue_content}'"
 
 # Identify Jira Issue, if multiple use | as delimiter
-JIRA_ISSUE_LIST="$(echo "${find_issue_content}" | egrep -o '[a-zA-Z]+-[0-9]+' | sort -uf | tr '\n' '|' | sed 's/.$//')"
+JIRA_ISSUE_LIST="$(echo "${find_issue_content}" | egrep -o '[a-zA-Z0-9]+-[0-9]+' | sort -uf | tr '\n' '|' | sed 's/.$//')"
 
 # If no issue, abort
 if [ -z "${JIRA_ISSUE_LIST}" ]; then


### PR DESCRIPTION
Updated regex will handle IDs like `ABC2-123`